### PR TITLE
Move to streams

### DIFF
--- a/motor/frameworks/asyncio.py
+++ b/motor/frameworks/asyncio.py
@@ -23,7 +23,6 @@ import ssl
 import sys
 
 import greenlet
-import collections
 
 
 def get_event_loop():
@@ -159,7 +158,8 @@ class AsyncioMotorSocket(asyncio.Protocol):
     """A fake socket instance that pauses and resumes the current greenlet.
 
     Pauses the calling greenlet when making blocking calls, and uses the
-    asyncio event loop to schedule the greenlet for resumption when I/O is ready.
+    asyncio event loop to schedule the greenlet for resumption when I/O
+    is ready.
 
     We only implement those socket methods actually used by PyMongo.
     """
@@ -168,8 +168,6 @@ class AsyncioMotorSocket(asyncio.Protocol):
         self.options = options
         self.timeout = None
         self.ctx = None
-        self._connected_future = asyncio.Future(loop=self.loop)
-        self._buffer_len = 0
         self._writer = None
         self._reader = None
 
@@ -190,8 +188,6 @@ class AsyncioMotorSocket(asyncio.Protocol):
     def settimeout(self, timeout):
         self.timeout = timeout
 
-
-
     @asyncio_motor_sock_method
     @asyncio.coroutine
     def connect(self):
@@ -200,7 +196,7 @@ class AsyncioMotorSocket(asyncio.Protocol):
         if is_unix_socket:
             path = self.options.address[0]
             reader, writer = yield from asyncio.open_unix_connection(
-                path, loop=self.loop, ssl=self.ctx )
+                path, loop=self.loop, ssl=self.ctx)
         else:
             host, port = self.options.address
             reader, writer = yield from asyncio.open_connection(

--- a/motor/frameworks/asyncio.py
+++ b/motor/frameworks/asyncio.py
@@ -154,7 +154,7 @@ def asyncio_motor_sock_method(method):
     return _motor_sock_method
 
 
-class AsyncioMotorSocket(asyncio.Protocol):
+class AsyncioMotorSocket:
     """A fake socket instance that pauses and resumes the current greenlet.
 
     Pauses the calling greenlet when making blocking calls, and uses the

--- a/motor/frameworks/asyncio.py
+++ b/motor/frameworks/asyncio.py
@@ -127,8 +127,8 @@ def asyncio_motor_sock_method(method):
                 if future:
                     future.cancel()
 
-                if self._transport:
-                    self._transport.abort()
+                if self._writer:
+                    self._writer.close()
 
                 child_gr.throw(socket.error("timed out"))
 
@@ -168,11 +168,10 @@ class AsyncioMotorSocket(asyncio.Protocol):
         self.options = options
         self.timeout = None
         self.ctx = None
-        self._transport = None
         self._connected_future = asyncio.Future(loop=self.loop)
-        self._buffer = collections.deque()
         self._buffer_len = 0
-        self._recv_future = asyncio.Future(loop=self.loop)
+        self._writer = None
+        self._reader = None
 
         if options.use_ssl:
             # TODO: cache at Pool level.
@@ -191,70 +190,40 @@ class AsyncioMotorSocket(asyncio.Protocol):
     def settimeout(self, timeout):
         self.timeout = timeout
 
+
+
     @asyncio_motor_sock_method
     @asyncio.coroutine
     def connect(self):
-        protocol_factory = lambda: self
-        # TODO: will call getaddrinfo again.
-        host, port = self.options.address
-        # socket module doesn't have an AF_UNIX constant on Windows.
         is_unix_socket = (self.options.family == getattr(socket,
                                                          'AF_UNIX', None))
         if is_unix_socket:
             path = self.options.address[0]
-            self._transport, protocol =(yield from self.loop.
-                create_unix_connection(protocol_factory, path,
-                                       ssl=self.ctx))
+            reader, writer = yield from asyncio.open_unix_connection(
+                path, loop=self.loop, ssl=self.ctx )
         else:
-            self._transport, protocol = yield from self.loop.create_connection(
-                protocol_factory, host, port,
-                ssl=self.ctx)
+            host, port = self.options.address
+            reader, writer = yield from asyncio.open_connection(
+                host=host, port=port, ssl=self.ctx, loop=self.loop)
+        self._reader, self._writer = reader, writer
 
     def sendall(self, data):
         assert greenlet.getcurrent().parent is not None,\
             "Should be on child greenlet"
 
         # TODO: backpressure? errors?
-        self._transport.write(data)
+        self._writer.write(data)
 
     @asyncio_motor_sock_method
     @asyncio.coroutine
     def recv(self, num_bytes):
-        while self._buffer_len < num_bytes:
-            yield from self._recv_future
-
-        data = bytes().join(self._buffer)
-        rv = data[:num_bytes]
-        remainder = data[num_bytes:]
-
-        self._buffer.clear()
-        if remainder:
-            self._buffer.append(remainder)
-
-        self._buffer_len = len(remainder)
-
+        rv = yield from self._reader.readexactly(num_bytes)
         return rv
 
     def close(self):
-        if self._transport:
-            self._transport.close()
+        if self._writer:
+            self._writer.close()
 
-    # Protocol interface.
-    def connection_made(self, transport):
-        pass
-        # self._connected_future.set_result(None)
-
-    def data_received(self, data):
-        self._buffer_len += len(data)
-        self._buffer.append(data)
-
-        # TODO: comment
-        future = self._recv_future
-        self._recv_future = asyncio.Future(loop=self.loop)
-        future.set_result(None)
-
-    def connection_lost(self, exc):
-        pass
 
 # A create_socket() function is part of Motor's framework interface.
 create_socket = AsyncioMotorSocket

--- a/test/asyncio_tests/test_asyncio_ssl.py
+++ b/test/asyncio_tests/test_asyncio_ssl.py
@@ -316,7 +316,7 @@ class TestAsyncIOSSL(AsyncIOTestCase):
         yield from collection.remove()
         uri = ('mongodb://%s@%s:%d/?authMechanism='
                'MONGODB-X509' % (
-               quote_plus(MONGODB_X509_USERNAME), host, port))
+                   quote_plus(MONGODB_X509_USERNAME), host, port))
 
         # SSL options aren't supported in the URI....
         auth_uri_client = AsyncIOMotorClient(uri,

--- a/test/asyncio_tests/test_asyncio_tail.py
+++ b/test/asyncio_tests/test_asyncio_tail.py
@@ -62,8 +62,8 @@ class MotorTailTest(AsyncIOTestCase):
         start = time()
         cursor = capped.find(tailable=True, await_data=True)
 
-        while (results != expected
-               and time() - start < MotorTailTest.expected_duration):
+        while (results != expected and
+               time() - start < MotorTailTest.expected_duration):
 
             while (yield from cursor.fetch_next):
                 doc = cursor.next_object()


### PR DESCRIPTION
I've changed `AsyncioMotorSocket`, so now it relies on `StreamReader` and `StreamWriter` interface instead implementing `asyncio.Protocol`. This simplifies code, what do you think?
